### PR TITLE
Update Colors for Labels and Interactive Elements on Sign-Up Page

### DIFF
--- a/chat-app/package.json
+++ b/chat-app/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "vite",
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/chat-app/src/pages/login/Login.tsx
+++ b/chat-app/src/pages/login/Login.tsx
@@ -23,7 +23,7 @@ const Login = () => {
         <form>
           <div>
             <label className="label p-2">
-              <span className="text-base label-text">Username</span>
+              <span className="text-base label-text text-white">Username</span>
             </label>
             <input
               type="text"
@@ -35,7 +35,7 @@ const Login = () => {
           </div>
           <div>
             <label className="label">
-              <span className="text-base label-text">Password</span>
+              <span className="text-base label-text text-white">Password</span>
             </label>
             <input
               type="password"
@@ -47,7 +47,7 @@ const Login = () => {
           </div>
           <Link
             to={"/signup"}
-            className="cursor-pointer text-sm  hover:underline hover:text-blue-600 mt-2"
+            className="cursor-pointer text-sm text-white hover:underline hover:text-blue-600 mt-2"
           >
             {"Don't"} have an account?
           </Link>

--- a/chat-app/src/pages/signup/GenderCheckBox.tsx
+++ b/chat-app/src/pages/signup/GenderCheckBox.tsx
@@ -5,10 +5,10 @@ const GenderCheckbox = ({ onCheckboxChange, selectedGender }) => {
     <div className="flex">
       <div className="form-control">
         <label className={`label gap-2 cursor-pointer`}>
-          <span className="label-text">Male</span>
+          <span className="label-text text-white">Male</span>
           <input
             type="checkbox"
-            className="checkbox border-slate-900"
+            className="checkbox border-white"
             checked={selectedGender === "male"}
             onChange={() => {
               onCheckboxChange("male");
@@ -18,10 +18,10 @@ const GenderCheckbox = ({ onCheckboxChange, selectedGender }) => {
       </div>
       <div className="form-control">
         <label className={`label gap-2 cursor-pointer`}>
-          <span className="label-text">Female</span>
+          <span className="label-text text-white">Female</span>
           <input
             type="checkbox"
-            className="checkbox border-slate-900"
+            className="checkbox border-white"
             checked={selectedGender === "female"}
             onChange={() => {
               onCheckboxChange("female");

--- a/chat-app/src/pages/signup/SignUp.tsx
+++ b/chat-app/src/pages/signup/SignUp.tsx
@@ -33,7 +33,7 @@ const SignUp = () => {
         <form onSubmit={HandleSubmit}>
           <div>
             <label className="label p-2">
-              <span className="text-base label-text">Full Name</span>
+              <span className="text-base label-text text-white">Full Name</span>
             </label>
             <input
               type="text"
@@ -47,7 +47,7 @@ const SignUp = () => {
           </div>
           <div>
             <label className="label p-2 ">
-              <span className="text-base label-text">Username</span>
+              <span className="text-base label-text text-white">Username</span>
             </label>
             <input
               type="text"
@@ -62,7 +62,7 @@ const SignUp = () => {
 
           <div>
             <label className="label">
-              <span className="text-base label-text">Password</span>
+              <span className="text-base label-text text-white">Password</span>
             </label>
             <input
               type="password"
@@ -76,7 +76,7 @@ const SignUp = () => {
           </div>
           <div>
             <label className="label">
-              <span className="text-base label-text">Confirm Password</span>
+              <span className="text-base label-text text-white">Confirm Password</span>
             </label>
             <input
               type="password"
@@ -95,7 +95,7 @@ const SignUp = () => {
           />
 
           <Link
-            className="text-sm hover:underline hover:text-blue-600 mt-2 inline-block"
+            className="text-sm hover:underline text-white hover:text-blue-600 mt-2 inline-block"
             to={"/login"}
           >
             Already have an account?


### PR DESCRIPTION
### Description:

This PR updates the color of various elements on the sign-up page to white for better visibility and consistency with the overall design:

#### Labels:

Full Name Label: Changed the color to white.
Username Label: Changed the color to white.
Password Label: Changed the color to white.
Confirm Password Label: Changed the color to white.
Male Label: Changed the color to white.
Female Label: Changed the color to white.
#### Interactive Elements:

"Already Have an Account?" Text: Changed the color to white.
Checkbox Borders: Changed the checkbox borders to white.

### Screenshots:
![image](https://github.com/user-attachments/assets/85f537e3-aa22-4298-9baa-065d2da95da2)
